### PR TITLE
Support React Native; use base-64 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Use `base-64` behind the scenes to enable React Native compatibility.
+
 ## 0.1.0
 
 - Start this log.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/mapbox/parse-mapbox-token.svg?token=FB2dZNVWaGo68KZnwz9M&branch=master)](https://travis-ci.com/mapbox/parse-mapbox-token)
 
-Parse a Mapbox API token, **in Node or the browser**.
+Parse a Mapbox API token, in any JS environment, including Node, browser, and React Native.
 
 Learn about Mapbox API tokens by reading [Mapbox's API documentation](https://www.mapbox.com/api-documentation/#tokens).
 
@@ -38,4 +38,4 @@ The following properties may or may not be present:
 - **client:** OAuth client for which the token was granted.
 - **impersonator:** ID of the user impersonating the account owner.
 
-The token's payload is parsed with [`window.atob`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/atob) in the browser and with [`Buffer`](https://nodejs.org/api/buffer.html) in Node.
+The token's payload is parsed with [`base-64`](https://github.com/mathiasbynens/base64).

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var base64 = require('base-64');
+
 var tokenCache = {};
 
 function parseToken(token) {
@@ -34,18 +36,10 @@ function parseToken(token) {
 
 function parsePaylod(rawPayload) {
   try {
-    if (typeof window !== 'undefined' && window.atob) {
-      return JSON.parse(atob(rawPayload));
-    }
-    if (typeof Buffer !== 'undefined') {
-      return JSON.parse(new Buffer(rawPayload, 'base64').toString());
-    }
+    return JSON.parse(base64.decode(rawPayload));
   } catch (parseError) {
     throw new Error('Invalid token');
   }
-  throw new Error(
-    'Unable to parse in an enviornment without window.atob (browsers) or Buffer (Node)'
-  );
 }
 
 function has(obj, key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,6 +209,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "browserify": "^16.2.0",
     "eslint": "^4.19.1",
     "tape": "^4.9.0"
+  },
+  "dependencies": {
+    "base-64": "^0.1.0"
   }
 }


### PR DESCRIPTION
Closes #1.

Adds a dependency on [base-64](https://www.npmjs.com/package/base-64), which is pretty small and spec complaint so should work great.

@nitaliano would you mind verifying that this library now works on React Native, before I merged & release?